### PR TITLE
Fixed the inconsistent size issue on resize and the type animation malfunction on the home screen.

### DIFF
--- a/src/experience/Home.js
+++ b/src/experience/Home.js
@@ -76,7 +76,7 @@ export default class Home {
         this.#typedIndividualsTraits = new Typed("#home .typed-element", {
             stringsElement: "#home .typed-strings",
             typeSpeed: 100,
-            backDelay: 2100,
+            backDelay: 700,
             backSpeed: 100,
             loop: true,
             cursorChar: "█",

--- a/src/experience/World.js
+++ b/src/experience/World.js
@@ -89,6 +89,7 @@ export default class World {
         this.currentViewType = viewType;
         this.currentView = this.views[viewType];
         this.subjects.push(this.currentView);
+        this.currentView.resize();
         this.currentView.set();
         if (this.hud.hudBoundary) {
             this.experience.mainCamera.focusCamera(this.hud.hudBoundary, 1);
@@ -103,15 +104,22 @@ export default class World {
 
     #includeBackIndicator() {
         const backIndicator = document.querySelector("#back-indicator");
+        if (backIndicator.classList.contains("show")) {
+            return;
+        }
         backIndicator.classList.remove("hide");
         backIndicator.classList.add("show");
-        backIndicator.addEventListener("click", () => {
-            backIndicator.classList.remove("show");
-            backIndicator.classList.add("hide");
-            this.hud.addFeedbackIcon();
+        backIndicator.addEventListener(
+            "click", 
+            () => {
+                backIndicator.classList.remove("show");
+                backIndicator.classList.add("hide");
+                this.hud.addFeedbackIcon();
 
-            this.setView("home");
-        });
+                this.setView("home");
+            }, 
+            { once: true }
+        );
     }
 
     resize() {


### PR DESCRIPTION
Once a 3D object is created but it is not part of the current screen view and the screen is resized, the object not part of the current screen does not get resized. And so, it remains the same when it is reintroduced to the current view screen. We fix it by resizing these objects before reintroducing them to the current view screen.

On the other hand, the type animation malfunctions when the animation is stopped during the cursor blinking stage and it is restarted before the cursor blinking stage ends and move on to the backspace stage. This results in typewriting and backspacing happening at the same moment in time causing the glitch. While this is a source code issue and we will have to patch it or let the owners of the package take care of the issue. For now, we fix it by reducing the cursor blinking stage's time duration called 'backDelay' in order to prevent the above mentioned issue from ever occuring in a humanly manner.